### PR TITLE
Add argument for just config file

### DIFF
--- a/cmd/play/main.go
+++ b/cmd/play/main.go
@@ -15,6 +15,7 @@ type flags struct {
    device bool
    single bool
    platform play.Platform
+   justConfig bool // New flag to indicate downloading just the configuration
 }
 
 func main() {
@@ -32,6 +33,7 @@ func main() {
    flag.Uint64Var(&f.app.Version, "v", 0, "version code")
    flag.Var(&f.platform, "p", fmt.Sprint(play.Platforms))
    flag.StringVar(&f.app.Languages, "l", "en-US,fr-FR,de-DE,it-IT,es-ES", "languages to download, comma separated")
+   flag.BoolVar(&f.justConfig, "justConfig", false, "download just the configuration (for split bundles only)")
    flag.Parse()
    http.No_Location()
    http.Verbose()

--- a/cmd/play/play.go
+++ b/cmd/play/play.go
@@ -173,17 +173,20 @@ func (f flags) do_delivery() error {
       return err
    }
    option.Location()
-   for _, apk := range client.Config_APKs() {
-      if url, ok := apk.URL(); ok {
-         if config, ok := apk.Config(); ok {
-            if sig, ok := apk.Signature(); ok {
-               err := f.download(url, f.app.APK(config), sig)
-               if err != nil {
-                  return err
+   if f.justConfig {
+      for _, apk := range client.Config_APKs() {
+         if url, ok := apk.URL(); ok {
+            if config, ok := apk.Config(); ok {
+               if sig, ok := apk.Signature(); ok {
+                  err := f.download(url, f.app.APK(config), sig)
+                  if err != nil {
+                     return err
+                  }
                }
             }
          }
       }
+      return nil
    }
    for _, obb := range client.OBB_Files() {
       if url, ok := obb.URL(); ok {


### PR DESCRIPTION
use case: you want to download all configurations/architectures for the same app, therefore when switching platforms you don't need to download the main apk each time.