### PR TITLE
Fix `oauth_token` auth request to avoid `MissingDroidguard` error

### DIFF
--- a/play/auth.go
+++ b/play/auth.go
@@ -14,6 +14,7 @@ func Exchange(oauth_token string) (*Refresh_Token, error) {
          "ACCESS_TOKEN": {"1"},
          "Token":        {oauth_token},
          "service":      {"ac2dm"},
+         "droidguard_results": {"null"},
       },
    )
    if err != nil {


### PR DESCRIPTION
Google appears to have recently started enforcing the `MissingDroidguard` check on the `oauth_token` endpoint. This error was initially triggered sporadically but now seems to be consistently enforced.

This change fixes the issue by explicitly adding `droidguard_results=null` to the auth request. Including this parameter prevents the server from rejecting the request with the `MissingDroidguard` error.

My assumption is that the issue started appearing due to a gradual rollout of updates on Google's infrastructure. As their servers are updated incrementally to maintain availability, some requests likely began hitting updated nodes earlier than others, which explains the intermittent errors observed in previous weeks.